### PR TITLE
Update Maven site deploy workflow version to v5

### DIFF
--- a/.github/workflows/maven-site-deploy.yml
+++ b/.github/workflows/maven-site-deploy.yml
@@ -26,6 +26,6 @@ concurrency:
 jobs:
   # Build the site with Maven
   build:
-    uses: sentrysoftware/workflows/.github/workflows/maven-site-deploy.yml@main
+    uses: sentrysoftware/workflows/.github/workflows/maven-site-deploy.yml@v5
     with:
       jdkVersion: ${{ inputs.jdkVersion }}


### PR DESCRIPTION
This pull request updates the Maven site deployment workflow to use a newer version of the shared workflow. This ensures the build process benefits from the latest improvements and fixes.

- CI/CD workflow update:
  * [`.github/workflows/maven-site-deploy.yml`](diffhunk://#diff-d951116e67a5880722bc5d83daac99d89aafb46fffa333ac2460df5c0f0f8671L29-R29): Changed the referenced workflow version from `main` to `v5` to use a specific, stable release of the deployment workflow.