### PR TITLE
Update Maven build workflow to use version v5

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -49,7 +49,7 @@ permissions:
 
 jobs:
   build:
-    uses: sentrysoftware/workflows/.github/workflows/maven-build.yml@v4
+    uses: sentrysoftware/workflows/.github/workflows/maven-build.yml@v5
     with:
       mavenPhases: ${{ inputs.mavenPhases }}
       jdkVersion: ${{ inputs.jdkVersion }}


### PR DESCRIPTION
This pull request updates the Maven build workflow to use the latest shared workflow version. The only change is updating the workflow reference from version 4 to version 5 in the `.github/workflows/maven-build.yml` file.